### PR TITLE
[ Feat ] 종류별 조회 기능 + 페이지네이션

### DIFF
--- a/src/main/java/com/sparta/hotitemcollector/domain/like/LikeController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/like/LikeController.java
@@ -18,11 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class LikeController {
+
     private final LikeService likeService;
 
     @PostMapping("/likes/{productId}")
-    public ResponseEntity<CommonResponse> createLike(@PathVariable ("productId") Long productId,
-                                                     @AuthenticationPrincipal UserDetailsImpl userDetails){
+    public ResponseEntity<CommonResponse> createLike(@PathVariable("productId") Long productId,
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // User를 받아오기
         User user = userDetails.getUser();
 
@@ -43,7 +44,7 @@ public class LikeController {
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
         List<ProductSimpleResponseDto> responseDtoList = likeService.getLikeProduct(
-            userDetails.getUser(),page-1,size);
+            userDetails.getUser(), page - 1, size);
         CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
             "좋아요한 상품 목록 조회 성공", 200, responseDtoList);
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/src/main/java/com/sparta/hotitemcollector/domain/like/LikeController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/like/LikeController.java
@@ -1,14 +1,18 @@
 package com.sparta.hotitemcollector.domain.like;
 
+import com.sparta.hotitemcollector.domain.product.ProductSimpleResponseDto;
 import com.sparta.hotitemcollector.domain.security.UserDetailsImpl;
 import com.sparta.hotitemcollector.domain.user.User;
 import com.sparta.hotitemcollector.global.common.CommonResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,5 +36,16 @@ public class LikeController {
             CommonResponse response = new CommonResponse<>("좋아요 취소 완료", 200, "");
             return new ResponseEntity<>(response, HttpStatus.OK);
         }
+    }
+
+    @GetMapping("/products/like")
+    public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getLikeProduct(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+        List<ProductSimpleResponseDto> responseDtoList = likeService.getLikeProduct(
+            userDetails.getUser());
+        CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
+            "좋아요한 상품 목록 조회 성공", 200, responseDtoList);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/like/LikeController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/like/LikeController.java
@@ -41,9 +41,9 @@ public class LikeController {
     @GetMapping("/products/like")
     public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getLikeProduct(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+        @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
         List<ProductSimpleResponseDto> responseDtoList = likeService.getLikeProduct(
-            userDetails.getUser());
+            userDetails.getUser(),page-1,size);
         CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
             "좋아요한 상품 목록 조회 성공", 200, responseDtoList);
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/src/main/java/com/sparta/hotitemcollector/domain/like/LikeRepository.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/like/LikeRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.hotitemcollector.domain.like;
 
 import com.sparta.hotitemcollector.domain.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,5 +11,5 @@ import java.util.Optional;
 public interface LikeRepository extends JpaRepository<Likes, Long> {
     Optional<Likes> findByProductIdAndUser(Long productId, User user);
 
-    List<Likes> findByUser(User user);
+    Page<Likes> findByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/like/LikeRepository.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/like/LikeRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Likes, Long> {
+
     Optional<Likes> findByProductIdAndUser(Long productId, User user);
 
     Page<Likes> findByUser(User user, Pageable pageable);

--- a/src/main/java/com/sparta/hotitemcollector/domain/like/LikeService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/like/LikeService.java
@@ -1,18 +1,15 @@
 package com.sparta.hotitemcollector.domain.like;
 
 import com.sparta.hotitemcollector.domain.product.Product;
-import com.sparta.hotitemcollector.domain.product.ProductRepository;
 import com.sparta.hotitemcollector.domain.product.ProductService;
+import com.sparta.hotitemcollector.domain.product.ProductSimpleResponseDto;
 import com.sparta.hotitemcollector.domain.user.User;
-import com.sparta.hotitemcollector.global.exception.CustomException;
-import com.sparta.hotitemcollector.global.exception.ErrorCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +25,7 @@ public class LikeService {
         if (existingLike.isPresent()) {
             // 좋아요가 이미 존재하면 삭제
             likeRepository.delete(existingLike.get());
+            productService.decreaseLikes(productId);
             return false; // 좋아요 취소
         } else {
             // 좋아요가 존재하지 않으면 생성
@@ -39,8 +37,18 @@ public class LikeService {
                     .build();
 
             likeRepository.save(like);
+            productService.increaseLikes(productId);
             return true; // 좋아요 생성
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductSimpleResponseDto> getLikeProduct(User user) {
+        List<Product> productList = findLikeProductIdByUser(user);
+
+        return productList.stream()
+            .map(ProductSimpleResponseDto::new)
+            .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/sparta/hotitemcollector/domain/like/LikeService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/like/LikeService.java
@@ -43,7 +43,7 @@ public class LikeService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProductSimpleResponseDto> getLikeProduct(User user) {
+    public List<ProductSimpleResponseDto> getLikeProduct(User user,int page, int size) {
         List<Product> productList = findLikeProductIdByUser(user);
 
         return productList.stream()

--- a/src/main/java/com/sparta/hotitemcollector/domain/like/LikeService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/like/LikeService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class LikeService {
+
     private final LikeRepository likeRepository;
     private final ProductService productService;
 
@@ -36,9 +37,9 @@ public class LikeService {
             Product product = productService.findById(productId);
 
             Likes like = Likes.builder()
-                    .user(user)
-                    .product(product)
-                    .build();
+                .user(user)
+                .product(product)
+                .build();
 
             likeRepository.save(like);
             productService.increaseLikes(productId);
@@ -47,9 +48,9 @@ public class LikeService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProductSimpleResponseDto> getLikeProduct(User user,int page, int size) {
+    public List<ProductSimpleResponseDto> getLikeProduct(User user, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<Product> productPage = findLikeProductIdByUser(user,pageable);
+        Page<Product> productPage = findLikeProductIdByUser(user, pageable);
 
         return productPage.getContent()
             .stream()

--- a/src/main/java/com/sparta/hotitemcollector/domain/like/LikeService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/like/LikeService.java
@@ -8,6 +8,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,19 +48,18 @@ public class LikeService {
 
     @Transactional(readOnly = true)
     public List<ProductSimpleResponseDto> getLikeProduct(User user,int page, int size) {
-        List<Product> productList = findLikeProductIdByUser(user);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Product> productPage = findLikeProductIdByUser(user,pageable);
 
-        return productList.stream()
+        return productPage.getContent()
+            .stream()
             .map(ProductSimpleResponseDto::new)
             .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public List<Product> findLikeProductIdByUser(User user) {
-        List<Likes> likes = likeRepository.findByUser(user);
-
-        return likes.stream()
-                .map(Likes::getProduct)
-                .toList();
+    public Page<Product> findLikeProductIdByUser(User user, Pageable pageable) {
+        Page<Likes> likesPage = likeRepository.findByUser(user, pageable);
+        return likesPage.map(Likes::getProduct);
     }
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/HotProductResponseDto.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/HotProductResponseDto.java
@@ -1,0 +1,14 @@
+package com.sparta.hotitemcollector.domain.product;
+
+import lombok.Getter;
+
+@Getter
+public class HotProductResponseDto {
+    private Long id;
+    private String name;
+
+    public HotProductResponseDto(Product product) {
+        this.id = product.getId();
+        this.name = product.getName();
+    }
+}

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/HotProductResponseDto.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/HotProductResponseDto.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 
 @Getter
 public class HotProductResponseDto {
+
     private Long id;
     private String name;
 

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/Product.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/Product.java
@@ -65,4 +65,12 @@ public class Product extends Timestamped {
         this.info = requestDto.getInfo();
         this.category = requestDto.getCategory();
     }
+
+    public void increaseLikes() {
+        this.likes++;
+    }
+
+    public void decreaseLikes() {
+        this.likes--;
+    }
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
@@ -66,9 +66,10 @@ public class ProductController {
 
     @GetMapping("/follow")
     public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getFollowProduct(
-        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
         List<ProductSimpleResponseDto> responseDtoList = productService.getFollowProduct(
-            userDetails.getUser());
+            userDetails.getUser(), page, size);
         CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
             "팔로우한 사용자의 상품 목록 조회 성공", 200, responseDtoList);
         return new ResponseEntity<>(response, HttpStatus.OK);
@@ -76,7 +77,8 @@ public class ProductController {
 
     @GetMapping("/like")
     public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getLikeProduct(
-        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
         List<ProductSimpleResponseDto> responseDtoList = productService.getLikeProduct(
             userDetails.getUser());
         CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
@@ -85,8 +87,9 @@ public class ProductController {
     }
 
     @GetMapping("/hot")
-    public ResponseEntity<CommonResponse<List<HotProductResponseDto>>> getHotProduct() {
-        List<HotProductResponseDto> responseDtoList = productService.getHotProduct();
+    public ResponseEntity<CommonResponse<List<HotProductResponseDto>>> getHotProduct(
+        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+        List<HotProductResponseDto> responseDtoList = productService.getHotProduct(page, size);
         CommonResponse<List<HotProductResponseDto>> response = new CommonResponse<>(
             "Hot Top 10 조회 성공", 200, responseDtoList);
         return new ResponseEntity<>(response, HttpStatus.OK);
@@ -94,9 +97,10 @@ public class ProductController {
 
     @GetMapping("/sale")
     public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getSaleProduct(
-        @AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam ProductStatus status) {
+        @AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam ProductStatus status,
+        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
         List<ProductSimpleResponseDto> responseDtoList = productService.getSaleProduct(
-            userDetails.getUser(), status);
+            userDetails.getUser(), status, page, size);
         CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
             "판매 상태에 따른 상품 목록 조회 성공", 200, responseDtoList);
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
@@ -75,17 +75,6 @@ public class ProductController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping("/like")
-    public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getLikeProduct(
-        @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
-        List<ProductSimpleResponseDto> responseDtoList = productService.getLikeProduct(
-            userDetails.getUser());
-        CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
-            "좋아요한 상품 목록 조회 성공", 200, responseDtoList);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
     @GetMapping("/hot")
     public ResponseEntity<CommonResponse<List<HotProductResponseDto>>> getHotProduct(
         @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
@@ -3,6 +3,7 @@ package com.sparta.hotitemcollector.domain.product;
 import com.sparta.hotitemcollector.domain.security.UserDetailsImpl;
 import com.sparta.hotitemcollector.global.common.CommonResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -59,5 +60,19 @@ public class ProductController {
         ProductResponseDto responseDto = productService.getProduct(productId);
         CommonResponse response = new CommonResponse("상품 단건 조회 성공", 200, responseDto);
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/follow")
+    public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getFollowProduct(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        List<ProductSimpleResponseDto> responseDtoList = productService.getFollowProduct(userDetails.getUser());
+        CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>("팔로우한 사용자의 상품 목록 조회 성공",200,responseDtoList);
+        return new ResponseEntity<>(response,HttpStatus.OK);
+    }
+
+    @GetMapping("/like")
+    public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getLikeProduct(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        List<ProductSimpleResponseDto> responseDtoList = productService.getLikeProduct(userDetails.getUser());
+        CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>("좋아요한 상품 목록 조회 성공",200,responseDtoList);
+        return new ResponseEntity<>(response,HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
@@ -67,9 +67,9 @@ public class ProductController {
     @GetMapping("/follow")
     public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getFollowProduct(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+        @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
         List<ProductSimpleResponseDto> responseDtoList = productService.getFollowProduct(
-            userDetails.getUser(), page, size);
+            userDetails.getUser(), page-1, size);
         CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
             "팔로우한 사용자의 상품 목록 조회 성공", 200, responseDtoList);
         return new ResponseEntity<>(response, HttpStatus.OK);
@@ -77,8 +77,8 @@ public class ProductController {
 
     @GetMapping("/hot")
     public ResponseEntity<CommonResponse<List<HotProductResponseDto>>> getHotProduct(
-        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
-        List<HotProductResponseDto> responseDtoList = productService.getHotProduct(page, size);
+        @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
+        List<HotProductResponseDto> responseDtoList = productService.getHotProduct(page-1, size);
         CommonResponse<List<HotProductResponseDto>> response = new CommonResponse<>(
             "Hot Top 10 조회 성공", 200, responseDtoList);
         return new ResponseEntity<>(response, HttpStatus.OK);
@@ -87,9 +87,9 @@ public class ProductController {
     @GetMapping("/sale")
     public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getSaleProduct(
         @AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam ProductStatus status,
-        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+        @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
         List<ProductSimpleResponseDto> responseDtoList = productService.getSaleProduct(
-            userDetails.getUser(), status, page, size);
+            userDetails.getUser(), status, page-1, size);
         CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
             "판매 상태에 따른 상품 목록 조회 성공", 200, responseDtoList);
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -81,6 +82,13 @@ public class ProductController {
     public ResponseEntity<CommonResponse<List<HotProductResponseDto>>> getHotProduct(){
         List<HotProductResponseDto> responseDtoList = productService.getHotProduct();
         CommonResponse<List<HotProductResponseDto>> response = new CommonResponse<>("Hot Top 10 조회 성공",200,responseDtoList);
+        return new ResponseEntity<>(response,HttpStatus.OK);
+    }
+
+    @GetMapping("/sale")
+    public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getSaleProduct(@AuthenticationPrincipal UserDetailsImpl userDetails,@RequestParam ProductStatus status){
+        List<ProductSimpleResponseDto> responseDtoList = productService.getSaleProduct(userDetails.getUser(),status);
+        CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>("판매 상태에 따른 상품 목록 조회 성공",200,responseDtoList);
         return new ResponseEntity<>(response,HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
@@ -69,7 +69,7 @@ public class ProductController {
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
         List<ProductSimpleResponseDto> responseDtoList = productService.getFollowProduct(
-            userDetails.getUser(), page-1, size);
+            userDetails.getUser(), page - 1, size);
         CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
             "팔로우한 사용자의 상품 목록 조회 성공", 200, responseDtoList);
         return new ResponseEntity<>(response, HttpStatus.OK);
@@ -78,7 +78,7 @@ public class ProductController {
     @GetMapping("/hot")
     public ResponseEntity<CommonResponse<List<HotProductResponseDto>>> getHotProduct(
         @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
-        List<HotProductResponseDto> responseDtoList = productService.getHotProduct(page-1, size);
+        List<HotProductResponseDto> responseDtoList = productService.getHotProduct(page - 1, size);
         CommonResponse<List<HotProductResponseDto>> response = new CommonResponse<>(
             "Hot Top 10 조회 성공", 200, responseDtoList);
         return new ResponseEntity<>(response, HttpStatus.OK);
@@ -89,7 +89,7 @@ public class ProductController {
         @AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam ProductStatus status,
         @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
         List<ProductSimpleResponseDto> responseDtoList = productService.getSaleProduct(
-            userDetails.getUser(), status, page-1, size);
+            userDetails.getUser(), status, page - 1, size);
         CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
             "판매 상태에 따른 상품 목록 조회 성공", 200, responseDtoList);
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
@@ -65,30 +65,40 @@ public class ProductController {
     }
 
     @GetMapping("/follow")
-    public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getFollowProduct(@AuthenticationPrincipal UserDetailsImpl userDetails){
-        List<ProductSimpleResponseDto> responseDtoList = productService.getFollowProduct(userDetails.getUser());
-        CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>("팔로우한 사용자의 상품 목록 조회 성공",200,responseDtoList);
-        return new ResponseEntity<>(response,HttpStatus.OK);
+    public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getFollowProduct(
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<ProductSimpleResponseDto> responseDtoList = productService.getFollowProduct(
+            userDetails.getUser());
+        CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
+            "팔로우한 사용자의 상품 목록 조회 성공", 200, responseDtoList);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @GetMapping("/like")
-    public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getLikeProduct(@AuthenticationPrincipal UserDetailsImpl userDetails){
-        List<ProductSimpleResponseDto> responseDtoList = productService.getLikeProduct(userDetails.getUser());
-        CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>("좋아요한 상품 목록 조회 성공",200,responseDtoList);
-        return new ResponseEntity<>(response,HttpStatus.OK);
+    public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getLikeProduct(
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<ProductSimpleResponseDto> responseDtoList = productService.getLikeProduct(
+            userDetails.getUser());
+        CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
+            "좋아요한 상품 목록 조회 성공", 200, responseDtoList);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @GetMapping("/hot")
-    public ResponseEntity<CommonResponse<List<HotProductResponseDto>>> getHotProduct(){
+    public ResponseEntity<CommonResponse<List<HotProductResponseDto>>> getHotProduct() {
         List<HotProductResponseDto> responseDtoList = productService.getHotProduct();
-        CommonResponse<List<HotProductResponseDto>> response = new CommonResponse<>("Hot Top 10 조회 성공",200,responseDtoList);
-        return new ResponseEntity<>(response,HttpStatus.OK);
+        CommonResponse<List<HotProductResponseDto>> response = new CommonResponse<>(
+            "Hot Top 10 조회 성공", 200, responseDtoList);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @GetMapping("/sale")
-    public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getSaleProduct(@AuthenticationPrincipal UserDetailsImpl userDetails,@RequestParam ProductStatus status){
-        List<ProductSimpleResponseDto> responseDtoList = productService.getSaleProduct(userDetails.getUser(),status);
-        CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>("판매 상태에 따른 상품 목록 조회 성공",200,responseDtoList);
-        return new ResponseEntity<>(response,HttpStatus.OK);
+    public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getSaleProduct(
+        @AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam ProductStatus status) {
+        List<ProductSimpleResponseDto> responseDtoList = productService.getSaleProduct(
+            userDetails.getUser(), status);
+        CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>(
+            "판매 상태에 따른 상품 목록 조회 성공", 200, responseDtoList);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductController.java
@@ -4,6 +4,7 @@ import com.sparta.hotitemcollector.domain.security.UserDetailsImpl;
 import com.sparta.hotitemcollector.global.common.CommonResponse;
 import jakarta.validation.Valid;
 import java.util.List;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -73,6 +74,13 @@ public class ProductController {
     public ResponseEntity<CommonResponse<List<ProductSimpleResponseDto>>> getLikeProduct(@AuthenticationPrincipal UserDetailsImpl userDetails){
         List<ProductSimpleResponseDto> responseDtoList = productService.getLikeProduct(userDetails.getUser());
         CommonResponse<List<ProductSimpleResponseDto>> response = new CommonResponse<>("좋아요한 상품 목록 조회 성공",200,responseDtoList);
+        return new ResponseEntity<>(response,HttpStatus.OK);
+    }
+
+    @GetMapping("/hot")
+    public ResponseEntity<CommonResponse<List<HotProductResponseDto>>> getHotProduct(){
+        List<HotProductResponseDto> responseDtoList = productService.getHotProduct();
+        CommonResponse<List<HotProductResponseDto>> response = new CommonResponse<>("Hot Top 10 조회 성공",200,responseDtoList);
         return new ResponseEntity<>(response,HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRepository.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRepository.java
@@ -2,13 +2,15 @@ package com.sparta.hotitemcollector.domain.product;
 
 import com.sparta.hotitemcollector.domain.user.User;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    List<Product> findByUserIn(List<User> users);
+    Page<Product> findByUserIn(List<User> users, Pageable pageable);
 
-    List<Product> findTop10ByOrderByLikesDesc();
+    Page<Product> findTop10ByOrderByLikesDesc(Pageable pageable);
 
-    List<Product> findByUserAndStatus(User user, ProductStatus status);
+    Page<Product> findByUserAndStatus(User user, ProductStatus status, Pageable pageable);
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRepository.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRepository.java
@@ -1,10 +1,10 @@
 package com.sparta.hotitemcollector.domain.product;
 
 import com.sparta.hotitemcollector.domain.user.User;
-import java.util.Optional;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    Optional<Product> findByUser(User user);
+    List<Product> findByUserIn(List<User> users);
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRepository.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRepository.java
@@ -9,4 +9,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findByUserIn(List<User> users);
 
     List<Product> findTop10ByOrderByLikesDesc();
+
+    List<Product> findByUserAndStatus(User user, ProductStatus status);
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRepository.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     List<Product> findByUserIn(List<User> users);
+
+    List<Product> findTop10ByOrderByLikesDesc();
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRepository.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRepository.java
@@ -1,6 +1,10 @@
 package com.sparta.hotitemcollector.domain.product;
 
+import com.sparta.hotitemcollector.domain.user.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    Optional<Product> findByUser(User user);
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRequestDto.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductRequestDto.java
@@ -1,6 +1,7 @@
 package com.sparta.hotitemcollector.domain.product;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
@@ -8,11 +9,11 @@ public class ProductRequestDto {
 
     @NotBlank(message = "상품의 이름을 입력해주세요.")
     private String name;
-    @NotBlank(message = "상품의 카테고리를 입력해주세요.")
+    @NotNull(message = "상품의 카테고리를 입력해주세요.")
     private ProductCategory category;
     @NotBlank(message = "상품의 이미지를 입력해주세요.")
     private String image;
-    @NotBlank(message = "상품의 가격을 입력해주세요.")
+    @NotNull(message = "상품의 가격을 입력해주세요.")
     private Long price;
     @NotBlank(message = "상품의 소개를 입력해주세요.")
     private String info;

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
@@ -2,7 +2,6 @@ package com.sparta.hotitemcollector.domain.product;
 
 import com.sparta.hotitemcollector.domain.follow.Follow;
 import com.sparta.hotitemcollector.domain.follow.FollowService;
-import com.sparta.hotitemcollector.domain.like.LikeService;
 import com.sparta.hotitemcollector.domain.user.User;
 import com.sparta.hotitemcollector.domain.user.UserService;
 import com.sparta.hotitemcollector.global.exception.CustomException;
@@ -20,10 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ProductService {
 
-    private UserService userService;
-    private ProductRepository productRepository;
-    private FollowService followService;
-    private LikeService likeService;
+    private final UserService userService;
+    private final ProductRepository productRepository;
+    private final FollowService followService;
 
     @Transactional
     public ProductResponseDto createProduct(ProductRequestDto requestDto, User user) {
@@ -93,15 +91,6 @@ public class ProductService {
             .collect(Collectors.toList());
     }
 
-    @Transactional(readOnly = true)
-    public List<ProductSimpleResponseDto> getLikeProduct(User user) {
-        List<Product> productList = likeService.findLikeProductIdByUser(user);
-
-        return productList.stream()
-            .map(ProductSimpleResponseDto::new)
-            .collect(Collectors.toList());
-    }
-
     public List<HotProductResponseDto> getHotProduct(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Product> productPage = productRepository.findTop10ByOrderByLikesDesc(pageable);
@@ -128,5 +117,16 @@ public class ProductService {
         return productRepository.findById(productId).orElseThrow(
             () -> new CustomException(ErrorCode.NOT_FOUND_PRODUCT)
         );
+    }
+
+    public void increaseLikes(Long productId){
+        Product product = findById(productId);
+        product.increaseLikes();
+        productRepository.save(product);
+    }
+    public void decreaseLikes(Long productId){
+        Product product = findById(productId);
+        product.decreaseLikes();
+        productRepository.save(product);
     }
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
@@ -9,6 +9,7 @@ import com.sparta.hotitemcollector.global.exception.CustomException;
 import com.sparta.hotitemcollector.global.exception.ErrorCode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,11 +76,16 @@ public class ProductService {
 
     public List<ProductSimpleResponseDto> getFollowProduct(User user) {
         List<Follow> followList = followService.getAllFollowers(user);
-        List<Product> productList = new ArrayList<>();
-        for (Follow follow : followList) {
-            Product product = findByUser(follow.getFollowing());
-            productList.add(product);
-        }
+
+        List<User> followingUsers = followList.stream()
+            .map(Follow::getFollowing)
+            .collect(Collectors.toList());
+
+        List<Product> productList = productRepository.findByUserIn(followingUsers);
+
+        return productList.stream()
+            .map(ProductSimpleResponseDto::new)
+            .collect(Collectors.toList());
     }
 
     public List<ProductSimpleResponseDto> getLikeProduct(User user) {
@@ -89,12 +95,6 @@ public class ProductService {
     public Product findById(Long productId) {
         return productRepository.findById(productId).orElseThrow(
             () -> new CustomException(ErrorCode.NOT_FOUND_PRODUCT)
-        );
-    }
-
-    public Product findByUser(User user){
-        return productRepository.findByUser(user).orElseThrow(
-            ()-> new CustomException(ErrorCode.NON_EXISTENT_PRODUCT)
         );
     }
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
@@ -93,7 +93,7 @@ public class ProductService {
     }
 
     public List<HotProductResponseDto> getHotProduct(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size,Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Product> productPage = productRepository.findTop10ByOrderByLikesDesc(pageable);
 
         return productPage.getContent()
@@ -105,7 +105,7 @@ public class ProductService {
     @Transactional(readOnly = true)
     public List<ProductSimpleResponseDto> getSaleProduct(User user, ProductStatus status, int page,
         int size) {
-        Pageable pageable = PageRequest.of(page, size,Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Product> productPage = productRepository.findByUserAndStatus(user, status, pageable);
 
         return productPage.getContent()
@@ -120,12 +120,13 @@ public class ProductService {
         );
     }
 
-    public void increaseLikes(Long productId){
+    public void increaseLikes(Long productId) {
         Product product = findById(productId);
         product.increaseLikes();
         productRepository.save(product);
     }
-    public void decreaseLikes(Long productId){
+
+    public void decreaseLikes(Long productId) {
         Product product = findById(productId);
         product.decreaseLikes();
         productRepository.save(product);

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
@@ -10,6 +10,9 @@ import com.sparta.hotitemcollector.global.exception.ErrorCode;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,16 +77,18 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProductSimpleResponseDto> getFollowProduct(User user) {
+    public List<ProductSimpleResponseDto> getFollowProduct(User user, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
         List<Follow> followList = followService.getAllFollowers(user);
 
         List<User> followingUsers = followList.stream()
             .map(Follow::getFollowing)
             .collect(Collectors.toList());
 
-        List<Product> productList = productRepository.findByUserIn(followingUsers);
+        Page<Product> productPage = productRepository.findByUserIn(followingUsers, pageable);
 
-        return productList.stream()
+        return productPage.getContent()
+            .stream()
             .map(ProductSimpleResponseDto::new)
             .collect(Collectors.toList());
     }
@@ -97,19 +102,24 @@ public class ProductService {
             .collect(Collectors.toList());
     }
 
-    public List<HotProductResponseDto> getHotProduct() {
-        List<Product> productList = productRepository.findTop10ByOrderByLikesDesc();
+    public List<HotProductResponseDto> getHotProduct(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Product> productPage = productRepository.findTop10ByOrderByLikesDesc(pageable);
 
-        return productList.stream()
+        return productPage.getContent()
+            .stream()
             .map(HotProductResponseDto::new)
             .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public List<ProductSimpleResponseDto> getSaleProduct(User user, ProductStatus status) {
-        List<Product> productList = productRepository.findByUserAndStatus(user, status);
+    public List<ProductSimpleResponseDto> getSaleProduct(User user, ProductStatus status, int page,
+        int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Product> productPage = productRepository.findByUserAndStatus(user, status, pageable);
 
-        return productList.stream()
+        return productPage.getContent()
+            .stream()
             .map(ProductSimpleResponseDto::new)
             .collect(Collectors.toList());
     }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
@@ -7,7 +7,6 @@ import com.sparta.hotitemcollector.domain.user.User;
 import com.sparta.hotitemcollector.domain.user.UserService;
 import com.sparta.hotitemcollector.global.exception.CustomException;
 import com.sparta.hotitemcollector.global.exception.ErrorCode;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -108,7 +107,7 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public List<ProductSimpleResponseDto> getSaleProduct(User user, ProductStatus status) {
-        List<Product> productList = productRepository.findByUserAndStatus(user,status);
+        List<Product> productList = productRepository.findByUserAndStatus(user, status);
 
         return productList.stream()
             .map(ProductSimpleResponseDto::new)

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
@@ -1,9 +1,14 @@
 package com.sparta.hotitemcollector.domain.product;
 
+import com.sparta.hotitemcollector.domain.follow.Follow;
+import com.sparta.hotitemcollector.domain.follow.FollowService;
+import com.sparta.hotitemcollector.domain.like.LikeService;
 import com.sparta.hotitemcollector.domain.user.User;
 import com.sparta.hotitemcollector.domain.user.UserService;
 import com.sparta.hotitemcollector.global.exception.CustomException;
 import com.sparta.hotitemcollector.global.exception.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +19,8 @@ public class ProductService {
 
     private UserService userService;
     private ProductRepository productRepository;
+    private FollowService followService;
+    private LikeService likeService;
 
     @Transactional
     public ProductResponseDto createProduct(ProductRequestDto requestDto, User user) {
@@ -66,9 +73,28 @@ public class ProductService {
         return responseDto;
     }
 
+    public List<ProductSimpleResponseDto> getFollowProduct(User user) {
+        List<Follow> followList = followService.getAllFollowers(user);
+        List<Product> productList = new ArrayList<>();
+        for (Follow follow : followList) {
+            Product product = findByUser(follow.getFollowing());
+            productList.add(product);
+        }
+    }
+
+    public List<ProductSimpleResponseDto> getLikeProduct(User user) {
+
+    }
+
     public Product findById(Long productId) {
         return productRepository.findById(productId).orElseThrow(
-            () -> new CustomException(ErrorCode.NON_EXISTENT_PRODUCT)
+            () -> new CustomException(ErrorCode.NOT_FOUND_PRODUCT)
+        );
+    }
+
+    public Product findByUser(User user){
+        return productRepository.findByUser(user).orElseThrow(
+            ()-> new CustomException(ErrorCode.NON_EXISTENT_PRODUCT)
         );
     }
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
@@ -96,6 +96,14 @@ public class ProductService {
             .collect(Collectors.toList());
     }
 
+    public List<HotProductResponseDto> getHotProduct() {
+        List<Product> productList = productRepository.findTop10ByOrderByLikesDesc();
+
+        return productList.stream()
+            .map(HotProductResponseDto::new)
+            .collect(Collectors.toList());
+    }
+
     public Product findById(Long productId) {
         return productRepository.findById(productId).orElseThrow(
             () -> new CustomException(ErrorCode.NOT_FOUND_PRODUCT)

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -76,7 +77,7 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public List<ProductSimpleResponseDto> getFollowProduct(User user, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         List<Follow> followList = followService.getAllFollowers(user);
 
         List<User> followingUsers = followList.stream()
@@ -92,7 +93,7 @@ public class ProductService {
     }
 
     public List<HotProductResponseDto> getHotProduct(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size,Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Product> productPage = productRepository.findTop10ByOrderByLikesDesc(pageable);
 
         return productPage.getContent()
@@ -104,7 +105,7 @@ public class ProductService {
     @Transactional(readOnly = true)
     public List<ProductSimpleResponseDto> getSaleProduct(User user, ProductStatus status, int page,
         int size) {
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size,Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Product> productPage = productRepository.findByUserAndStatus(user, status, pageable);
 
         return productPage.getContent()

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
@@ -89,7 +89,11 @@ public class ProductService {
     }
 
     public List<ProductSimpleResponseDto> getLikeProduct(User user) {
+        List<Product> productList = likeService.findLikeProductIdByUser(user);
 
+        return productList.stream()
+            .map(ProductSimpleResponseDto::new)
+            .collect(Collectors.toList());
     }
 
     public Product findById(Long productId) {

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductService.java
@@ -74,6 +74,7 @@ public class ProductService {
         return responseDto;
     }
 
+    @Transactional(readOnly = true)
     public List<ProductSimpleResponseDto> getFollowProduct(User user) {
         List<Follow> followList = followService.getAllFollowers(user);
 
@@ -88,6 +89,7 @@ public class ProductService {
             .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public List<ProductSimpleResponseDto> getLikeProduct(User user) {
         List<Product> productList = likeService.findLikeProductIdByUser(user);
 
@@ -101,6 +103,15 @@ public class ProductService {
 
         return productList.stream()
             .map(HotProductResponseDto::new)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductSimpleResponseDto> getSaleProduct(User user, ProductStatus status) {
+        List<Product> productList = productRepository.findByUserAndStatus(user,status);
+
+        return productList.stream()
+            .map(ProductSimpleResponseDto::new)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductSimpleResponseDto.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductSimpleResponseDto.java
@@ -8,5 +8,11 @@ public class ProductSimpleResponseDto {
     private String name;
     private String image;
     private Long userId;
-    private Long userName;
+
+    public ProductSimpleResponseDto(Product product) {
+        this.id = product.getId();
+        this.name = product.getName();
+        this.image = product.getImage();
+        this.userId =product.getUser().getId();
+    }
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductSimpleResponseDto.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductSimpleResponseDto.java
@@ -16,7 +16,7 @@ public class ProductSimpleResponseDto {
         this.name = product.getName();
         this.image = product.getImage();
         this.userId = product.getUser().getId();
-        this.userName=product.getUser().getNickname();
+        this.userName = product.getUser().getNickname();
     }
 }
 

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductSimpleResponseDto.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductSimpleResponseDto.java
@@ -4,15 +4,19 @@ import lombok.Getter;
 
 @Getter
 public class ProductSimpleResponseDto {
+
     private Long id;
     private String name;
     private String image;
     private Long userId;
+    private String userName;
 
     public ProductSimpleResponseDto(Product product) {
         this.id = product.getId();
         this.name = product.getName();
         this.image = product.getImage();
-        this.userId =product.getUser().getId();
+        this.userId = product.getUser().getId();
+        this.userName=product.getUser().getNickname();
     }
 }
+

--- a/src/main/java/com/sparta/hotitemcollector/domain/product/ProductSimpleResponseDto.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/product/ProductSimpleResponseDto.java
@@ -1,0 +1,12 @@
+package com.sparta.hotitemcollector.domain.product;
+
+import lombok.Getter;
+
+@Getter
+public class ProductSimpleResponseDto {
+    private Long id;
+    private String name;
+    private String image;
+    private Long userId;
+    private Long userName;
+}

--- a/src/main/java/com/sparta/hotitemcollector/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/hotitemcollector/global/exception/ErrorCode.java
@@ -15,9 +15,6 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR"),
 
     // 각 Service에서 필요한 ErrorCode 추가
-    NON_EXISTENT_PRODUCT(HttpStatus.BAD_REQUEST, "아이디에 맞는 상품을 찾을 수 없습니다."),
-    NOT_SAME_USER(HttpStatus.BAD_REQUEST, "사용자가 일치하지 않아 요청을 처리할 수 없습니다."),
-    ALREADY_SOLD_OUT(HttpStatus.BAD_REQUEST, "이미 판매 완료된 상품입니다."),
 
     // Token
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
@@ -33,7 +30,10 @@ public enum ErrorCode {
 
 
     // Product
-    NOT_FOUND_PRODUCT(HttpStatus.NOT_FOUND, "NOT FOUND PRODUCT"),
+    NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
+    NOT_SAME_USER(HttpStatus.BAD_REQUEST, "사용자가 일치하지 않아 요청을 처리할 수 없습니다."),
+    ALREADY_SOLD_OUT(HttpStatus.BAD_REQUEST, "이미 판매 완료된 상품입니다."),
+    NON_EXISTENT_PRODUCT(HttpStatus.NO_CONTENT,"해당 사용자가 판매하는 상품이 없습니다."),
 
     // Cart
     NOT_FOUND_CART(HttpStatus.NOT_FOUND, "NOT FOUND CART"),


### PR DESCRIPTION
종류별 조회 기능 + 페이지네이션 (default size = 10) 

- 팔로우 사용자 상품 조회 (`상품 등록` 최신순 정렬)
- 좋아요 상품 조회 (`좋아요 등록` 최신순 정렬)
- Hot 10 상품 조회 (`좋아요 많은 순` + `상품 등록` 최신순 정렬)
- 판매상태에 따른 상품 조회 (`상품 등록` 최신순 정렬)

참고 ) likeService와 productService 순환참조 문제를 해결하기 위해 '좋아요한 상품 조회' 기능 코드는 like쪽으로 옮겼습니다.