### PR TITLE
Feat/#32

### DIFF
--- a/src/main/java/com/sparta/hotitemcollector/domain/cart/CartController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/cart/CartController.java
@@ -26,10 +26,10 @@ public class CartController {
 	private final CartService cartService;
 
 	@PostMapping("/{productId}")
-	public ResponseEntity<CommonResponse> createCartItem(@PathVariable("productId") Long productId,
+	public ResponseEntity<CommonResponse<CartItemResponseDto>> createCartItem(@PathVariable("productId") Long productId,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
 		CartItemResponseDto responseDto = cartService.createCartItem(userDetails.getUser(), productId);
-		CommonResponse response = new CommonResponse<>("장바구니에 상품 담기 성공", 201, responseDto);
+		CommonResponse<CartItemResponseDto> response = new CommonResponse<>("장바구니에 상품 담기 성공", 201, responseDto);
 		return new ResponseEntity<>(response, HttpStatus.CREATED);
 	}
 
@@ -42,10 +42,12 @@ public class CartController {
 	}
 
 	@GetMapping
-	public ResponseEntity<CommonResponse> getCart(@RequestParam(defaultValue = "1") int page,
+	public ResponseEntity<CommonResponse<List<CartItemResponseDto>>> getCartItems(
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "10") int size,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		List<CartItemResponseDto> responseDtoList = cartService.getCart(page, userDetails.getUser());
-		CommonResponse response = new CommonResponse<>("장바구니 조회 성공", 200, responseDtoList);
+		List<CartItemResponseDto> responseDtoList = cartService.getCartItems(page, size, userDetails.getUser());
+		CommonResponse<List<CartItemResponseDto>> response = new CommonResponse<>("장바구니 조회 성공", 200, responseDtoList);
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/cart/CartService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/cart/CartService.java
@@ -60,9 +60,9 @@ public class CartService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<CartItemResponseDto> getCart(int page, User user) {
+	public List<CartItemResponseDto> getCartItems(int page, int size, User user) {
 		Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
-		Pageable pageable = PageRequest.of(page - 1, 10, sort);
+		Pageable pageable = PageRequest.of(page - 1, size, sort);
 
 		Page<CartItem> cartItemPage = cartItemRepository.findAllByUserId(user.getId(), pageable);
 

--- a/src/main/java/com/sparta/hotitemcollector/domain/order/OrderController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/order/OrderController.java
@@ -66,9 +66,11 @@ public class OrderController {
 	public ResponseEntity<CommonResponse<List<OrderItemBySellerResponseDto>>> getOrdersBySeller(
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "10") int size,
+		@RequestParam(defaultValue = "#{T(java.time.LocalDateTime).now().minusMonths(3)}") LocalDateTime startDate,
+		@RequestParam(defaultValue = "#{T(java.time.LocalDateTime).now()}") LocalDateTime endDate,
 		@RequestParam(required = false) OrderStatus status,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		List<OrderItemBySellerResponseDto> responseDtoList = orderService.getOrdersAllBySeller(page, size, status, userDetails.getUser());
+		List<OrderItemBySellerResponseDto> responseDtoList = orderService.getOrdersAllBySeller(page, size, startDate, endDate, status, userDetails.getUser());
 
 		CommonResponse<List<OrderItemBySellerResponseDto>> response = new CommonResponse("판매자의 주문 목록을 조회 성공했습니다.", 200, responseDtoList);
 		return new ResponseEntity<>(response, HttpStatus.OK);

--- a/src/main/java/com/sparta/hotitemcollector/domain/order/OrderController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/order/OrderController.java
@@ -1,5 +1,6 @@
 package com.sparta.hotitemcollector.domain.order;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
@@ -30,40 +31,46 @@ public class OrderController {
 	private final OrderService orderService;
 
 	@PostMapping("/buy")
-	public ResponseEntity<CommonResponse> createOrder(@RequestBody OrderRequestDto orderRequestDto,
+	public ResponseEntity<CommonResponse<OrderResponseDto>> createOrder(@RequestBody OrderRequestDto orderRequestDto,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
 		OrderResponseDto responseDto = orderService.createOrder(orderRequestDto,
 			userDetails.getUser());
 
-		CommonResponse response = new CommonResponse("주문이 완료되었습니다.", 201, responseDto);
+		CommonResponse<OrderResponseDto> response = new CommonResponse("주문이 완료되었습니다.", 201, responseDto);
 		return new ResponseEntity<>(response, HttpStatus.CREATED);
 	}
 
 	@GetMapping("/buy")
-	public ResponseEntity<CommonResponse> getOrdersAllByBuyer(@RequestParam(defaultValue = "1") int page,
+	public ResponseEntity<CommonResponse<List<OrderResponseDto>>> getOrdersAllByBuyer(
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "10") int size,
+		@RequestParam(defaultValue = "#{T(java.time.LocalDateTime).now().minusMonths(3)}") LocalDateTime startDate,
+		@RequestParam(defaultValue = "#{T(java.time.LocalDateTime).now()}") LocalDateTime endDate,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		List<OrderResponseDto> responseDtoList = orderService.getOrdersAllByBuyer(page, userDetails.getUser());
+		List<OrderResponseDto> responseDtoList = orderService.getOrdersAllByBuyer(page, size, startDate, endDate, userDetails.getUser());
 
-		CommonResponse responses = new CommonResponse("구매자의 주문 목록을 조회 성공했습니다.", 200, responseDtoList);
+		CommonResponse<List<OrderResponseDto>> responses = new CommonResponse("구매자의 주문 목록을 조회 성공했습니다.", 200, responseDtoList);
 		return new ResponseEntity<>(responses, HttpStatus.OK);
 	}
 
 	@GetMapping("/buy/{orderId}")
-	public ResponseEntity<CommonResponse> getOrderByBuyer(@PathVariable("orderId") Long orderId,
+	public ResponseEntity<CommonResponse<OrderResponseDto>> getOrderByBuyer(@PathVariable("orderId") Long orderId,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
 		OrderResponseDto responseDto = orderService.getOrderByBuyer(orderId, userDetails.getUser());
 
-		CommonResponse response = new CommonResponse("구매자의 단건 주문을 조회 성공했습니다.", 200, responseDto);
+		CommonResponse<OrderResponseDto> response = new CommonResponse("구매자의 단건 주문을 조회 성공했습니다.", 200, responseDto);
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
 	@GetMapping("/sell")
-	public ResponseEntity<CommonResponse> getOrdersBySeller(@RequestParam(defaultValue = "1") int page,
+	public ResponseEntity<CommonResponse<List<OrderItemBySellerResponseDto>>> getOrdersBySeller(
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "10") int size,
 		@RequestParam(required = false) OrderStatus status,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
-		List<OrderItemBySellerResponseDto> responseDtoList = orderService.getOrdersAllBySeller(page, status, userDetails.getUser());
+		List<OrderItemBySellerResponseDto> responseDtoList = orderService.getOrdersAllBySeller(page, size, status, userDetails.getUser());
 
-		CommonResponse response = new CommonResponse("판매자의 주문 목록을 조회 성공했습니다.", 200, responseDtoList);
+		CommonResponse<List<OrderItemBySellerResponseDto>> response = new CommonResponse("판매자의 주문 목록을 조회 성공했습니다.", 200, responseDtoList);
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
@@ -78,3 +85,5 @@ public class OrderController {
 	}
 
 }
+
+

--- a/src/main/java/com/sparta/hotitemcollector/domain/order/OrderRepository.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/order/OrderRepository.java
@@ -1,9 +1,11 @@
 package com.sparta.hotitemcollector.domain.order;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Orders, Long> {
-	Page<Orders> findAllByUserId(Long userId, Pageable pageable);
+	Page<Orders> findAllByUserIdAndCreatedAtBetween(Long id, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 }

--- a/src/main/java/com/sparta/hotitemcollector/domain/order/OrderService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/order/OrderService.java
@@ -2,9 +2,7 @@ package com.sparta.hotitemcollector.domain.order;
 
 import static com.sparta.hotitemcollector.domain.order.OrderStatus.SHIPMENT_START;
 
-import com.sparta.hotitemcollector.domain.product.entity.Product;
-import com.sparta.hotitemcollector.domain.product.entity.ProductStatus;
-import com.sparta.hotitemcollector.domain.product.service.ProductService;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,6 +20,9 @@ import com.sparta.hotitemcollector.domain.order.dto.OrderResponseDto;
 import com.sparta.hotitemcollector.domain.order.dto.OrderStatusRequestDto;
 import com.sparta.hotitemcollector.domain.orderitem.OrderItem;
 import com.sparta.hotitemcollector.domain.orderitem.OrderItemRepository;
+import com.sparta.hotitemcollector.domain.product.entity.Product;
+import com.sparta.hotitemcollector.domain.product.entity.ProductStatus;
+import com.sparta.hotitemcollector.domain.product.service.ProductService;
 import com.sparta.hotitemcollector.domain.user.User;
 import com.sparta.hotitemcollector.global.exception.CustomException;
 import com.sparta.hotitemcollector.global.exception.ErrorCode;
@@ -72,14 +73,13 @@ public class OrderService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<OrderResponseDto> getOrdersAllByBuyer(int page, User user) {
+	public List<OrderResponseDto> getOrdersAllByBuyer(int page, int size, LocalDateTime startDate, LocalDateTime endDate, User user) {
 
 		Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
-		Pageable pageable = PageRequest.of(page - 1, 5, sort);
+		Pageable pageable = PageRequest.of(page - 1, size, sort);
+		Page<Orders> orderPage = orderRepository.findAllByUserIdAndCreatedAtBetween(user.getId(), startDate, endDate, pageable);
 
-		Page<Orders> orderList = orderRepository.findAllByUserId(user.getId(), pageable);
-
-		return orderList.getContent()
+		return orderPage.getContent()
 			.stream()
 			.map(OrderResponseDto::new)
 			.collect(Collectors.toList());
@@ -97,10 +97,10 @@ public class OrderService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<OrderItemBySellerResponseDto> getOrdersAllBySeller(int page, OrderStatus status, User user) {
+	public List<OrderItemBySellerResponseDto> getOrdersAllBySeller(int page, int size, OrderStatus status, User user) {
 
 		Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
-		Pageable pageable = PageRequest.of(page - 1, 5, sort);
+		Pageable pageable = PageRequest.of(page - 1, size, sort);
 		Page<OrderItem> orderItemPage = Page.empty(pageable);
 		List<Product> productList = productService.findByUserAndStatus(user, ProductStatus.SOLD_OUT);
 

--- a/src/main/java/com/sparta/hotitemcollector/domain/order/OrderService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/order/OrderService.java
@@ -97,7 +97,8 @@ public class OrderService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<OrderItemBySellerResponseDto> getOrdersAllBySeller(int page, int size, OrderStatus status, User user) {
+	public List<OrderItemBySellerResponseDto> getOrdersAllBySeller(int page, int size,
+		LocalDateTime startDate, LocalDateTime endDate, OrderStatus status, User user) {
 
 		Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
 		Pageable pageable = PageRequest.of(page - 1, size, sort);
@@ -105,10 +106,10 @@ public class OrderService {
 		List<Product> productList = productService.findByUserAndStatus(user, ProductStatus.SOLD_OUT);
 
 		if (status == null) {
-			orderItemPage = orderItemRepository.findAllByProductIn(productList, pageable);
+			orderItemPage = orderItemRepository.findAllByCreatedAtBetweenAndProductIn(startDate, endDate, productList, pageable);
 		}
 		if (status != null) {
-			orderItemPage = orderItemRepository.findAllByStatusAndProductIn(status, productList, pageable);
+			orderItemPage = orderItemRepository.findAllByStatusAndCreatedAtBetweenAndProductIn(status, startDate, endDate, productList, pageable);
 		}
 
 		return orderItemPage.getContent()

--- a/src/main/java/com/sparta/hotitemcollector/domain/orderitem/OrderItemRepository.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/orderitem/OrderItemRepository.java
@@ -1,6 +1,6 @@
 package com.sparta.hotitemcollector.domain.orderitem;
 
-import com.sparta.hotitemcollector.domain.product.entity.Product;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -8,8 +8,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparta.hotitemcollector.domain.order.OrderStatus;
+import com.sparta.hotitemcollector.domain.product.entity.Product;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
-	Page<OrderItem> findAllByProductIn(List<Product> productList, Pageable pageable);
-	Page<OrderItem> findAllByStatusAndProductIn(OrderStatus status, List<Product> productList, Pageable pageable);
+	Page<OrderItem> findAllByCreatedAtBetweenAndProductIn(LocalDateTime startDate, LocalDateTime endDate, List<Product> productList, Pageable pageable);
+
+	Page<OrderItem> findAllByStatusAndCreatedAtBetweenAndProductIn(OrderStatus status, LocalDateTime startDate, LocalDateTime endDate, List<Product> productList, Pageable pageable);
 }


### PR DESCRIPTION
* 구매자의 주문 목록 다건 조회에서, 전체 조회를 기간별 조회로 수정하였습니다.
    * date값이 입력되지 않은 경우 기본 현재~3개월 전의 시점을 조회할 수 있도록 하였습니다.


---

(HTTP테스트코드 예시)
\### getOrdersAllByBuyer
GET localhost:8080/orders/buy?page=1&size=10&startDate=2024-07-25T16:08:02.753601&endDate=2024-07-25T16:08:02.753605
Content-Type: application/json
Authorization: {{access}}

{

}

---


* 기존 페이지네이션 조회에서 임의로 결정해두었던 페이지의 size값을 입력받을 수 있도록 수정하였습니다.

* 일부 함수명을 보다 직관적으로 수정하였습니다.

* CommonResponse의 제네릭 타입을 채워주었습니다.


