### PR TITLE
Feat/#59 주문 상세 페이지 연동

### DIFF
--- a/frontend/src/components/DetailOrder.vue
+++ b/frontend/src/components/DetailOrder.vue
@@ -2,7 +2,7 @@
 import {onMounted, ref} from 'vue';
 import Cookies from "js-cookie";
 import axios from "axios";
-import {useRoute} from "vue-router";
+import {useRoute, useRouter} from "vue-router";
 
 export default {
   setup() {
@@ -37,6 +37,8 @@ export default {
     const getStatusIndex = (status) => {
       return statusMapping[status] !== undefined ? statusMapping[status] : 0;
     };
+
+    const router = useRouter();
 
     const search = () => {
       alert(`검색 유형: ${searchType.value}, 검색어: ${searchQuery.value}`)
@@ -83,10 +85,13 @@ export default {
 
     const goToProductDetail = (productId) => {
       alert(`상품 ID ${productId}의 상세 페이지로 이동합니다.`)
+      router.push({ name: 'DetailProductPage', params: { productId } });
     }
 
     const goToSellerDetail = (sellerId) => {
       alert(`판매자 ID ${sellerId}의 상세 페이지로 이동합니다.`)
+      // 아직 안되는 듯
+      // router.push({ name: 'OtherProfilePage', params: { sellerId } });
     }
 
     const accessToken = Cookies.get('access_token');
@@ -118,7 +123,6 @@ export default {
             image: item.productImage.imageUrl,
             currentStatusIndex: getStatusIndex(item.orderStatus)
           }));
-          console.log(products)
         }
       } catch (err) {
         console.error('Failed to fetch order details:', err);

--- a/frontend/src/components/DetailOrder.vue
+++ b/frontend/src/components/DetailOrder.vue
@@ -26,6 +26,18 @@ export default {
     const deliveryStatuses = ref(['결제완료', '상품준비중', '배송중', '배송완료']);
     const currentStatusIndex = ref(0); // 현재 상태 (배송완료)
 
+    const statusMapping = {
+      '결제 완료': 0,
+      '상품 준비중': 1,
+      '배송 중': 2,
+      '배송 완료':3
+    };
+
+    // 문자열을 인덱스로 변경
+    const getStatusIndex = (status) => {
+      return statusMapping[status] !== undefined ? statusMapping[status] : 0;
+    };
+
     const search = () => {
       alert(`검색 유형: ${searchType.value}, 검색어: ${searchQuery.value}`)
     }
@@ -104,8 +116,9 @@ export default {
             seller: item.sellerNickname,
             sellerId: item.sellerId,
             image: item.productImage.imageUrl,
-            status: item.orderStatus
+            currentStatusIndex: getStatusIndex(item.orderStatus)
           }));
+          console.log(products)
         }
       } catch (err) {
         console.error('Failed to fetch order details:', err);
@@ -208,18 +221,8 @@ export default {
         </div>
         <div class="order-summary">
           <h2>주문 상품 정보</h2>
-          <div class="delivery-status">
-            <h3>배송 상태</h3>
-            <div class="status-bar">
-              <div v-for="(status, index) in deliveryStatuses" :key="status"
-                   :class="['status-step', { active: index <= currentStatusIndex }]">
-                <div class="status-icon">{{ index + 1 }}</div>
-                <div class="status-label">{{ status }}</div>
-              </div>
-            </div>
-          </div>
-          <div v-for="product in products" :key="product.id" class="product-item" @click="goToProductDetail(product.id)">
-            <div class="product-content">
+          <div v-for="product in products" :key="product.id" class="product-item">
+            <div class="product-content" @click="goToProductDetail(product.id)">
               <img :src="product.image" :alt="product.name" class="product-image">
               <div class="product-info">
                 <div>
@@ -228,6 +231,16 @@ export default {
                      @click.stop="goToSellerDetail(product.sellerId)">{{ product.seller }}</a>
                 </div>
                 <span>{{ product.price.toLocaleString() }}원</span>
+              </div>
+            </div>
+            <div class="delivery-status">
+              <h3>배송 상태</h3>
+              <div class="status-bar">
+                <div v-for="(status, index) in deliveryStatuses" :key="status"
+                     :class="['status-step', { active: index <= product.currentStatusIndex }]">
+                  <div class="status-icon">{{ index + 1 }}</div>
+                  <div class="status-label">{{ status }}</div>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/components/DetailOrder.vue
+++ b/frontend/src/components/DetailOrder.vue
@@ -2,6 +2,7 @@
 import {onMounted, ref} from 'vue';
 import Cookies from "js-cookie";
 import axios from "axios";
+import {useRoute} from "vue-router";
 
 export default {
   setup() {
@@ -18,8 +19,9 @@ export default {
 
     // product를 배열로 설정
     const products = ref([]);
-
-    const orderData = ref(null);
+    //const orderData = ref(null);
+    const route = useRoute();
+    const orderId = route.query.orderId;
 
     const deliveryStatuses = ref(['결제완료', '상품준비중', '배송중', '배송완료']);
     const currentStatusIndex = ref(0); // 현재 상태 (배송완료)
@@ -79,24 +81,23 @@ export default {
 
     const fetchOrderDetail = async () => {
       try {
-        const response = await axios.get('http://localhost:8080/orders/buy', {
+        const response = await axios.get(`http://localhost:8080/order/buy/${orderId}`, {
           headers: {
             'Authorization': accessToken
           }
         });
 
-        const orderDataList = response.data.result;
+        const orderDataResponse = response.data.result;
 
-        if (orderDataList && orderDataList.length > 0) {
-          const order = orderDataList[0];
-          orderData.value = order;
+        if (orderDataResponse) {
+          orderDataResponse.value = orderDataResponse;
           shippingInfo.value = {
-            name: order.userName,
-            phone: order.phoneNumber,
-            address: order.address
+            name: orderDataResponse.userName,
+            phone: orderDataResponse.phoneNumber,
+            address: orderDataResponse.address
           };
 
-          products.value = order.orderItemResponseDtoList.map(item => ({
+          products.value = orderDataResponse.orderItemResponseDtoList.map(item => ({
             id: item.productId,
             name: item.productName,
             price: item.price,

--- a/frontend/src/components/OrderPage.vue
+++ b/frontend/src/components/OrderPage.vue
@@ -201,7 +201,7 @@ export default {
               });
 
               alert('결제 검증 성공');
-              router.push({name: 'DetailOrder'})
+              router.push({ name: 'DetailOrder', query: { orderId: orderId } });
               console.log('결제 검증 성공:', verifyResponse.data);
             } catch (error) {
               alert('결제 검증 실패');

--- a/src/main/java/com/sparta/hotitemcollector/domain/order/OrderController.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/order/OrderController.java
@@ -42,6 +42,15 @@ public class OrderController {
 		return new ResponseEntity<>(responses, HttpStatus.OK);
 	}
 
+	@GetMapping("/order/buy/{orderId}")
+	public ResponseEntity<CommonResponse<OrderResponseDto>> getOrderByBuyer(@PathVariable("orderId") Long orderId,
+																			@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		OrderResponseDto responseDto = orderService.getOrderByBuyer(orderId, userDetails.getUser());
+
+		CommonResponse<OrderResponseDto> response = new CommonResponse("구매자의 단건 주문을 조회 성공했습니다.", 200, responseDto);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
 	@GetMapping("/orders/sell")
 	public ResponseEntity<CommonResponse<List<OrderItemBySellerResponseDto>>> getOrdersBySeller(
 		@RequestParam(defaultValue = "#{T(java.time.LocalDate).now().minusMonths(3)}")

--- a/src/main/java/com/sparta/hotitemcollector/domain/order/OrderService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/order/OrderService.java
@@ -49,6 +49,17 @@ public class OrderService {
 	}
 
 	@Transactional(readOnly = true)
+	public OrderResponseDto getOrderByBuyer(Long orderId, User user) {
+		Orders order = findOrderById(orderId);
+
+		if (!user.getId().equals(order.getUser().getId())) {
+			throw new CustomException(ErrorCode.NOT_SAME_USER);
+		}
+
+		return new OrderResponseDto(order);
+	}
+
+	@Transactional(readOnly = true)
 	public List<OrderItemBySellerResponseDto> getOrdersAllBySeller(LocalDateTime startDate, LocalDateTime endDate, String status, User user) {
 
 		Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");

--- a/src/main/java/com/sparta/hotitemcollector/domain/order/OrderStatus.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/order/OrderStatus.java
@@ -7,7 +7,7 @@ public enum OrderStatus {
     SHIPMENT_START("배송 시작"),
     SHIPPING("배송 중"),
     SHIPPING_DONE("배송 완료"),
-    ORDERED("주문 완료"),
+    ORDERED("상품 준비중"),
     PAID("결제 완료"),
     PAID_READY("결제 대기중"),
     ORDER_CANCEL("주문 취소");

--- a/src/main/java/com/sparta/hotitemcollector/domain/payment/PaymentService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/payment/PaymentService.java
@@ -130,7 +130,10 @@ public class PaymentService {
 
 			// 해당 Order의 모든 OrderItem 상태를 변경
 			List<OrderItem> orderItemList = orderService.findOrderItemsByOrderId(payment.getOrder().getId());
-			orderItemList.forEach(orderItem -> orderItem.updateOrderItemStatus(OrderStatus.PAID));
+			orderItemList.forEach(orderItem -> {
+				orderItem.updateOrderItemStatus(OrderStatus.PAID);
+				productService.updateStatus(orderItem.getId());
+			});
 
 		} else {
 			throw new IllegalArgumentException("결제 금액이 일치하지 않습니다.");


### PR DESCRIPTION
주문 상세페이지 연동 완료했습니다.

orderId에 따라 단건 조회 하여 
1개의 주문에 2개 이상의 상품이 존재할 시 각 상품에 따른 상태바를 가지도록 수정하였습니다.
<img width="2032" alt="스크린샷 2024-07-29 오후 6 03 02" src="https://github.com/user-attachments/assets/eacf934a-9a83-4e7e-8ed4-dedbfdfc157e">

각 상품을 선택하면 해당 상품 ID를 통해 상세 페이지로 이동하도록 연결하였습니다.
<img width="2032" alt="스크린샷 2024-07-29 오후 6 03 11" src="https://github.com/user-attachments/assets/127b7b8f-5fc8-417d-b93b-3c1beee28aab">
