### PR TITLE
Fix/#71

### DIFF
--- a/frontend/src/components/DetailProductPage.vue
+++ b/frontend/src/components/DetailProductPage.vue
@@ -34,8 +34,8 @@
             <div class="product-actions-container">
               <p class="product-price">{{ formatPrice(product.price) }}원</p>
               <div class="buy-actions">
-                <button class="add-to-cart" @click="addToCart">장바구니 담기</button>
-                <button class="buy-now" @click="buyNow">구매하기</button>
+                <button v-if="isLoggedIn" class="add-to-cart" @click="addToCart">장바구니 담기</button>
+                <button v-if="isLoggedIn" class="buy-now" @click="buyNow">구매하기</button>
               </div>
             </div>
           </div>
@@ -45,9 +45,9 @@
     <AppFooter/>
   </div>
 <!--카트 모달-->
-  <div v-if="showCartModal" class="modal-overlay" @click.self="showCartModal = false">
+  <div v-if="showModal" class="modal-overlay" @click.self= "showModal = false">
     <div class="modal-container">
-      <button class="close-btn" @click="showCartModal = false">&times;</button>
+      <button class="close-btn" @click="showModal = false">&times;</button>
       <h1>{{ buttonText }}</h1>
       <button v-if="showGoToCartButton" @click="goToCart">장바구니로 이동하기</button>
     </div>
@@ -81,7 +81,7 @@ export default {
     const route = useRoute(); // useRoute를 통해 현재 라우트에 접근
     const productId = route.params.productId; // 라우트 파라미터에서 productId를 가져옴
     const accessToken = Cookies.get('access_token')
-    const showCartModal = ref(false);
+    const showModal = ref(false);
     const showGoToCartButton = ref(false);
     const cartError = ref(false)
     const buttonText = ref('')
@@ -89,6 +89,11 @@ export default {
 
     // 기본 프로필 이미지 URL
     const defaultProfileImage = defaultUserImage;
+
+    const checkLoginStatus = () => {
+      isLoggedIn.value = Boolean(accessToken); // 토큰이 있으면 로그인 상태로 간주
+    };
+    onMounted(checkLoginStatus);
 
     // Product 초기화
     const product = ref({
@@ -181,6 +186,9 @@ export default {
         console.log('팔로우 성공')
       } catch (error) {
         console.error('팔로우 실패:', error);
+        buttonText.value ='자신은 팔로우할 수 없습니다.'
+        showGoToCartButton.value = false
+        showModal.value = true
       }
     };
 
@@ -246,13 +254,12 @@ export default {
         console.log(response)
         buttonText.value = '장바구니에 상품을 담았습니다.'
         cartError.value = false
-        showCartModal.value = true
+        showModal.value = true
         showGoToCartButton.value = true
 
       }).catch(error => {
         /*에러가 있는 상황*/
          cartError.value = true
-        // showCartModal.value = true
 
         if (error.response.data.message){
           errorMessage.value = error.response.data.message
@@ -268,7 +275,7 @@ export default {
           buttonText.value = '상품을 장바구니에 담는 중 오류가 발생했습니다.'
           showGoToCartButton.value = false
         }
-        showCartModal.value = true
+        showModal.value = true
         console.error(error); // 에러 처리
       })
     }
@@ -293,8 +300,8 @@ export default {
     }
 
     const switchToCart = () => {
-      showCartModal.value = false
-      showCartModal.value = true
+      showModal.value = false
+      showModal.value = true
     }
 
     return {
@@ -303,7 +310,7 @@ export default {
       currentImage,
       isFollowing,
       isLiked,
-      showCartModal,
+      showModal,
       formatPrice,
       toggleFollow,
       toggleLike,

--- a/src/main/java/com/sparta/hotitemcollector/domain/payment/PaymentService.java
+++ b/src/main/java/com/sparta/hotitemcollector/domain/payment/PaymentService.java
@@ -66,6 +66,11 @@ public class PaymentService {
 		for (Long itemId : requestDto.getProductItemList()) {
 			// 기존 cartItem에서 제품을 찾는 것에서 제품 id를 바로 입력하도록 변경
 			Product product = productService.findById(itemId);
+
+			if (product.getUser().getId().equals(user.getId())) {
+				throw new CustomException(ErrorCode.SAME_USER_PRODUCT);
+			}
+
 			OrderItem orderItem = orderService.createOrderItem(order, product);
 
 			totalAmount = totalAmount.add(product.getPrice());


### PR DESCRIPTION
## 물건 상세정보페이지입니다.

* (백) 결제서비스 -> 상품을 올린 유저와 구매하는 유저가 같을 수 없도록 예외처리 코드 추가

----
## 화면

* 상품을 올린 유저와 구매하는 유저가 같으면 해당 화면에서 팔로우, 장바구니 ,구매 X
(장바구니)
![image](https://github.com/user-attachments/assets/f6f1293d-9b73-4f16-b6a3-faaf331e378b)
(구매) -> 만약 상세정보 페이지에서 해당 기능을 막으려면 로그인한 유저가 누구인지 알아내는 api를 새로 만들어야 할 것 같습니다.
![image](https://github.com/user-attachments/assets/ecf3afc9-3366-4e4f-974a-efe47405ed40)
(팔로우)
![image](https://github.com/user-attachments/assets/8a8be05f-630e-46b6-9d5d-9a37884c8441)


* 상품 좋아요는 가능합니다.

---

* 비로그인 유저는 버튼 비활성화
![image](https://github.com/user-attachments/assets/23259556-c164-4498-b241-319c53640724)


---
